### PR TITLE
[edit] remove TWMS cross

### DIFF
--- a/src/mapping/boss/twms.js
+++ b/src/mapping/boss/twms.js
@@ -85,32 +85,6 @@ const BossList = [
     defeatType: 'day',
     defeatTime: 1,
   },
-  // 簡單庫洛斯
-  {
-    id: 7,
-    name: 'cross',
-    difficulties: [
-      {
-        difficulty: 'easy',
-        mesos: 800000,
-      },
-    ],
-    defeatType: 'day',
-    defeatTime: 1,
-  },
-  // 普通庫洛斯
-  {
-    id: 8,
-    name: 'cross',
-    difficulties: [
-      {
-        difficulty: 'normal',
-        mesos: 1342000,
-      },
-    ],
-    defeatType: 'week',
-    defeatTime: 1,
-  },
   // 濃姬
   {
     id: 9,


### PR DESCRIPTION
Delete easy and normal cross in TWMS
刪除簡單與普通庫洛斯
因應 TMS V234 降魔的十字旅團關閉公告 改動
link: https://tw.beanfun.com/maplestory/bulletin?bid=60052